### PR TITLE
docs: add GitHub profile stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
+# Henryoman
+
 - front end / typescript / next.js / Go / Solana / Rust
 - currently learning Godot
+
+## GitHub Stats
+![Henryoman's GitHub stats](https://github-readme-stats.vercel.app/api?username=Henryoman&show_icons=true&count_private=true)
+
+## Top Languages
+![Top Languages](https://github-readme-stats.vercel.app/api/top-langs/?username=Henryoman&layout=compact)
+
+## Streak
+![GitHub Streak](https://github-readme-streak-stats.herokuapp.com/?user=Henryoman)
+
+## Activity Graph
+![GitHub Activity Graph](https://github-readme-activity-graph.cyclic.app/graph?username=Henryoman&theme=react-dark)
+
+## Trophies
+![trophy](https://github-profile-trophy.vercel.app/?username=Henryoman&theme=onestar&margin-w=15&margin-h=15)


### PR DESCRIPTION
## Summary
- expand profile README with GitHub stats, language breakdown, streak, activity graph, and trophies

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689807e50968832b80c3e4aac24318ef