### PR TITLE
docs: keep only languages and streak

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
+# Henryoman
+
 - front end / typescript / next.js / Go / Solana / Rust
 - currently learning Godot
+
+## Top Languages
+![Top Languages](https://github-readme-stats.vercel.app/api/top-langs/?username=Henryoman&layout=compact&exclude_repo=games)
+
+## Streak
+![GitHub Streak](https://github-readme-streak-stats.herokuapp.com/?user=Henryoman)
+


### PR DESCRIPTION
## Summary
- drop stats, activity graph, and trophies from profile README
- show top languages excluding the `games` repo and keep streak tracker

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689807e50968832b80c3e4aac24318ef